### PR TITLE
Add GH action to check for email addresses in issues and comments

### DIFF
--- a/.github/workflows/check-for-emails.yml
+++ b/.github/workflows/check-for-emails.yml
@@ -1,0 +1,18 @@
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+jobs:
+  find_emails:
+    runs-on: ubuntu-latest
+    name: Check for emails in issue comments
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Scan comment
+      id: scan
+      uses: seisvelas/comment-email-address-alerts@v3.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        exemptions: test,example.com,flowcrypt.com


### PR DESCRIPTION
Last time when I updated every repo to use the new version, I did so manually via the GitHub interface. But then it turned out I forgot some.

So, this time I decided to be lazy and write a little [script](https://gist.github.com/seisvelas/522f95e23bb48e6523ee3c8c92ef2f5a) to check all of them. Here was the output:

```
➜  Code python3 emails_updated.py
error checking repo fine-uploader, status code 404
fine-uploader does not have the new action
```

As far as I can tell, this is the only repo still missing the action. Therefore, I'm adding it!

Next time I update it, I'll also make sure to write a script to push the change to every repo and open a PR.